### PR TITLE
Fix IC remote text field to have path to gcs

### DIFF
--- a/examples/image_classification/Image_Classification_using_PyTorch_and_🔭_Galileo_Remote_Data.ipynb
+++ b/examples/image_classification/Image_Classification_using_PyTorch_and_🔭_Galileo_Remote_Data.ipynb
@@ -306,6 +306,8 @@
     "            if column not in STANDARD_DATA_COLUMNS_CV\n",
     "        ]\n",
     "\n",
+    "        bucket_prefix = \"gs://galileo-public-data/CV_datasets/ImageNet15_animals/\"\n",
+    "        self.ds[\"text\"] = bucket_prefix + self.ds[\"path\"]\n",
     "        # 🔭🌕 Galileo logging -- Log Input Data\n",
     "        dq.log_image_dataset(\n",
     "            dataset=self.ds,\n",


### PR DESCRIPTION
Was running https://colab.research.google.com/github/rungalileo/examples/blob/main/examples/image_classification/Image_Classification_using_PyTorch_and_%F0%9F%94%AD_Galileo_Remote_Data.ipynb#scrollTo=eViQAp_AGD6j

and ran into small issue 