### PR TITLE
fix: data emb column in dq.finish

### DIFF
--- a/examples/sequence_to_sequence/LLM_Fine_Tuning_using_🤗Encoder_Decoder_Models🤗_and_🔭_Galileo.ipynb
+++ b/examples/sequence_to_sequence/LLM_Fine_Tuning_using_🤗Encoder_Decoder_Models🤗_and_🔭_Galileo.ipynb
@@ -544,7 +544,7 @@
       },
       "outputs": [],
       "source": [
-        "dq.finish()"
+        "dq.finish(data_embs_col=\"input\")"
       ]
     }
   ],

--- a/examples/sequence_to_sequence/LLM_Fine_Tuning_with_DQ_using_API_and_🔭_Galileo.ipynb
+++ b/examples/sequence_to_sequence/LLM_Fine_Tuning_with_DQ_using_API_and_🔭_Galileo.ipynb
@@ -569,7 +569,7 @@
       },
       "outputs": [],
       "source": [
-        "dq.finish()"
+        "dq.finish(data_embs_col=\"input\")"
       ]
     }
   ],


### PR DESCRIPTION
Specify the column for data embeddings (defaults to `"text"` which works in TC related tasks but not seq2seq since we use "`input`" and "`target`")