### PR TITLE
create new notebook example

### DIFF
--- a/examples/Custom Chain + Tool + Protect in Observe/Sample_Observe+Tool+Protect+NonLangchain.ipynb
+++ b/examples/Custom Chain + Tool + Protect in Observe/Sample_Observe+Tool+Protect+NonLangchain.ipynb
@@ -1,0 +1,287 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Qt32QfvLH7LY"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install galileo-observe galileo-protect openai"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import galileo_protect as gp\n",
+        "from openai import AzureOpenAI\n",
+        "import galileo_observe as observe\n",
+        "import datetime, os, json"
+      ],
+      "metadata": {
+        "id": "5aDjpnaCIcuX"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Azure OpenAI Stuff"
+      ],
+      "metadata": {
+        "id": "IgB9mx2tIMc5"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "os.environ[\"AZURE_OPENAI_API_KEY\"]=\"\" # Your API Key from Azure"
+      ],
+      "metadata": {
+        "id": "nm2Z-vhEFt_m"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "client = AzureOpenAI(\n",
+        "    api_key=os.environ.get(\"AZURE_OPENAI_API_KEY\"),\n",
+        "    api_version=\"2024-02-15-preview\",\n",
+        "    azure_endpoint = \"\"# Your deployment endpoint\n",
+        "    )"
+      ],
+      "metadata": {
+        "id": "HRd5uKHHFX3k"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Galileo Stuff"
+      ],
+      "metadata": {
+        "id": "AF9s73ZwIO3t"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "os.environ[\"GALILEO_CONSOLE_URL\"]=\"\" # The URL to your console\n",
+        "os.environ[\"GALILEO_API_KEY\"]=\"\" # Bottom Left Icon > Settings > API Keys"
+      ],
+      "metadata": {
+        "id": "9k8OBfNQNyYf"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "project = gp.create_project('bot_protect_example')\n",
+        "project_id = project.id\n",
+        "\n",
+        "observe_logger = observe.ObserveWorkflows(project_name=\"bot_observe_example\")\n",
+        "\n",
+        "stage = gp.create_stage(name=\"first_stage\", project_id=project_id)\n",
+        "stage_id = stage.id"
+      ],
+      "metadata": {
+        "id": "g0YwfIoCD0sy"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Payload from Galileo Protect\n",
+        "def protect_payload(input: str, output: str):\n",
+        "  return gp.Payload(\n",
+        "      input=input,\n",
+        "      output=output\n",
+        "  )"
+      ],
+      "metadata": {
+        "id": "UD-4YC3K3YPu"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Function from Galileo Protect\n",
+        "def protect_galileo(input: str, output: str):\n",
+        "    protect_out = gp.invoke(\n",
+        "        payload=protect_payload(input, output),\n",
+        "        prioritized_rulesets=[\n",
+        "            {\n",
+        "                \"rules\": [\n",
+        "                    {\n",
+        "                        \"metric\": \"pii\",\n",
+        "                        \"operator\": \"contains\",\n",
+        "                        \"target_value\": \"ssn\",\n",
+        "                    },\n",
+        "                ],\n",
+        "                \"action\": {\n",
+        "                    \"type\": \"OVERRIDE\",\n",
+        "                    \"choices\": [\n",
+        "                        \"Personal Identifiable Information detected in the model output. Sorry, I cannot answer that question.\"\n",
+        "                    ],\n",
+        "                },\n",
+        "            },\n",
+        "        ],\n",
+        "        stage_id=stage_id,\n",
+        "        timeout=3,\n",
+        "    )\n",
+        "    return protect_out"
+      ],
+      "metadata": {
+        "id": "UJgZwIf71Tc3"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# This is the function that we want the model to be able to call\n",
+        "def get_delivery_date(order_id: str) -> str:\n",
+        "    return datetime.datetime.now()"
+      ],
+      "metadata": {
+        "id": "BM6sg7ol88jW"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Define the tools you would like to use\n",
+        "tools = [\n",
+        "    {\n",
+        "        \"type\": \"function\",\n",
+        "        \"function\": {\n",
+        "            \"name\": \"get_delivery_date\",\n",
+        "            \"description\": \"Get the delivery date for a customer's order. Call this whenever you need to know the delivery date, for example when a customer asks 'Where is my package'\",\n",
+        "            \"parameters\": {\n",
+        "                \"type\": \"object\",\n",
+        "                \"properties\": {\n",
+        "                    \"order_id\": {\n",
+        "                        \"type\": \"string\",\n",
+        "                        \"description\": \"The customer's order ID.\",\n",
+        "                    },\n",
+        "                },\n",
+        "                \"required\": [\"order_id\"],\n",
+        "                \"additionalProperties\": False,\n",
+        "            },\n",
+        "        }\n",
+        "    }\n",
+        "]"
+      ],
+      "metadata": {
+        "id": "inqwSZsuwSXk"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Conversational Flow\n",
+        "inputs = [\n",
+        "{\"role\": \"system\", \"content\": \"You are a helpful customer support assistant. Use the supplied tools to assist the user.\"},\n",
+        "{\"role\": \"user\", \"content\": \"Hi, can you tell me the delivery date for my order?\"},\n",
+        "{\"role\": \"user\", \"content\": \"My order number is 12345.\"}\n",
+        "]"
+      ],
+      "metadata": {
+        "id": "OzzT0VwC_L_-"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "for i, prompt in enumerate(inputs):\n",
+        "    if prompt[\"role\"] == \"system\":\n",
+        "        wf = observe_logger.add_workflow(input={\"input\": prompt[\"content\"]}, output={\"output\": str(tools)}, name=\"CustomWorkflow\")\n",
+        "\n",
+        "    if prompt[\"role\"] == \"user\":\n",
+        "        current_messages = inputs[:i+1]\n",
+        "        # Conduct chat completion\n",
+        "        response = client.chat.completions.create(\n",
+        "          model=\"gpt-35-turbo\",\n",
+        "          messages=current_messages,\n",
+        "          tools=tools,\n",
+        "        )\n",
+        "        output_message = response.choices[0].message\n",
+        "\n",
+        "        # Check if it is an LLM or a Tool message\n",
+        "        if output_message.content is not None:\n",
+        "            wf.add_llm(\n",
+        "            input=prompt[\"content\"],\n",
+        "            output=output_message.content,\n",
+        "            model=\"gpt-35-turbo\",\n",
+        "            input_tokens=response.usage.prompt_tokens,\n",
+        "            output_tokens=response.usage.completion_tokens,\n",
+        "            total_tokens=response.usage.total_tokens,\n",
+        "            metadata={\"Node\": \"LLM\"}\n",
+        "            )\n",
+        "        elif output_message.tool_calls is not None:\n",
+        "            order_id = json.loads(response.choices[0].message.tool_calls[0].function.arguments)[\"order_id\"]\n",
+        "            tool_output = get_delivery_date(order_id)\n",
+        "            wf.add_tool(\n",
+        "            input=response.choices[0].message.tool_calls[0].function.arguments,\n",
+        "            output=f\"Your delivery date is {tool_output}.\",\n",
+        "            name=response.choices[0].message.tool_calls[0].function.name,\n",
+        "            metadata={\"Node\": \"Function\"}\n",
+        "            )\n",
+        "\n",
+        "        # On LLM steps, also run Protect\n",
+        "        if output_message.content is not None:\n",
+        "          response_protect = protect_galileo(prompt[\"content\"], output_message.content)\n",
+        "\n",
+        "          wf.add_protect(\n",
+        "              payload=protect_payload(prompt[\"content\"], output_message.content),\n",
+        "              response=response_protect,\n",
+        "              metadata={\"Node\": \"Protect\"}\n",
+        "          )\n",
+        "\n",
+        "    # Conclude the workflow\n",
+        "    wf.conclude(output={\"output\": output_message.content})\n",
+        "\n",
+        "# Upload all logged workflows to Galileo after processing\n",
+        "observe_logger.upload_workflows()"
+      ],
+      "metadata": {
+        "id": "Q72VnqmBaiMV"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
# User description
uses custom chain, per feedback add as an example and link out instead of in the docs https://github.com/rungalileo/docs-mintlify/pull/86

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduces a new Jupyter notebook example that demonstrates how to integrate <code>galileo-observe</code> and <code>galileo-protect</code> within a custom tool-calling workflow. Provides a practical implementation of logging LLM and tool steps while applying real-time protection rules for PII detection.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/examples/74?tool=ast>(Baz)</a>.